### PR TITLE
Unit test improvements

### DIFF
--- a/SRTX/Double_buffer_ut.cpp
+++ b/SRTX/Double_buffer_ut.cpp
@@ -17,10 +17,10 @@ namespace SRTX {
         Double_buffer<int> db;
 
         CPPUNIT_ASSERT_EQUAL(true, db.is_valid());
-	}
+    }
 
     void Double_buffer_ut::test_write_and_read_back_value()
-	{
+    {
         Double_buffer<int> db;
         int wval = 9;
         int rval;
@@ -30,27 +30,27 @@ namespace SRTX {
         CPPUNIT_ASSERT_EQUAL(true, db.write(wval));
         CPPUNIT_ASSERT_EQUAL(true, db.read(rval));
         CPPUNIT_ASSERT_EQUAL(wval, rval);
-	}
+    }
 
     void Double_buffer_ut::test_write_and_read_value_multiple_times()
-	{
+    {
         Double_buffer<int> db;
         int wval = 9;
         int rval;
 
-		for(int i = 0; i < 3; i++) {
-			/* Write a value and make sure we can read it back;
-			 */
-			CPPUNIT_ASSERT_EQUAL(true, db.write(wval));
-			CPPUNIT_ASSERT_EQUAL(true, db.read(rval));
-			CPPUNIT_ASSERT_EQUAL(wval, rval);
-			/* Then do it again.
-			 */
-		}
-	}
+        for(int i = 0; i < 3; i++) {
+            /* Write a value and make sure we can read it back;
+             */
+            CPPUNIT_ASSERT_EQUAL(true, db.write(wval));
+            CPPUNIT_ASSERT_EQUAL(true, db.read(rval));
+            CPPUNIT_ASSERT_EQUAL(wval, rval);
+            /* Then do it again.
+             */
+        }
+    }
 
     void Double_buffer_ut::test_read_more_data_than_allocated()
-	{
+    {
         Double_buffer<int> db;
         Base_double_buffer *bdb = &db;
         int wval = 9;
@@ -61,11 +61,11 @@ namespace SRTX {
          */
         CPPUNIT_ASSERT_EQUAL(false, bdb->read(&wval, sizeof(int) + 1));
         CPPUNIT_ASSERT_EQUAL(false, bdb->write(&wval, sizeof(int) + 1));
-	}
+    }
 
 #if 0 // Not repeatable with some machines.
-	void Double_buffer_ut::test_exhausted_memory()
-	{
+    void Double_buffer_ut::test_exhausted_memory()
+    {
         /* Assume that we cannot allocate a double buffer of type array of the
          * maximum number of ints. (Exhaust memory).
          */
@@ -74,7 +74,7 @@ namespace SRTX {
         CPPUNIT_ASSERT_EQUAL(false, db_big.is_valid());
         CPPUNIT_ASSERT_EQUAL(false, db_big.write(&wval, sizeof(int)));
         CPPUNIT_ASSERT_EQUAL(false, db_big.read(&rval, sizeof(int)));
-	}
+    }
 #endif
 
     void Double_buffer_ut::test_double_buffer_copy()
@@ -95,12 +95,12 @@ namespace SRTX {
         CPPUNIT_ASSERT_EQUAL(true, copy_entry(db2, db, sizeof(int)));
         CPPUNIT_ASSERT_EQUAL(true, db2.read(rval));
         CPPUNIT_ASSERT_EQUAL(wval, rval);
-	}
+    }
 
-	void Double_buffer_ut::test_double_buffer_copy_too_much()
-	{
-		Double_buffer<int> db;
-		Double_buffer<int> db2;
+    void Double_buffer_ut::test_double_buffer_copy_too_much()
+    {
+        Double_buffer<int> db;
+        Double_buffer<int> db2;
 
         /* Now let's try some copy operations that should fail.
          */

--- a/SRTX/Double_buffer_ut.cpp
+++ b/SRTX/Double_buffer_ut.cpp
@@ -12,12 +12,16 @@ namespace SRTX {
     {
     }
 
-    void Double_buffer_ut::test_double_buffer()
+    void Double_buffer_ut::test_double_buffer_initialization()
     {
         Double_buffer<int> db;
 
         CPPUNIT_ASSERT_EQUAL(true, db.is_valid());
+	}
 
+    void Double_buffer_ut::test_write_and_read_back_value()
+	{
+        Double_buffer<int> db;
         int wval = 9;
         int rval;
 
@@ -26,21 +30,42 @@ namespace SRTX {
         CPPUNIT_ASSERT_EQUAL(true, db.write(wval));
         CPPUNIT_ASSERT_EQUAL(true, db.read(rval));
         CPPUNIT_ASSERT_EQUAL(wval, rval);
+	}
 
-        /* Do it again.
-         */
-        CPPUNIT_ASSERT_EQUAL(true, db.write(++wval));
-        CPPUNIT_ASSERT_EQUAL(true, db.read(rval));
-        CPPUNIT_ASSERT_EQUAL(wval, rval);
+    void Double_buffer_ut::test_write_and_read_value_multiple_times()
+	{
+        Double_buffer<int> db;
+        int wval = 9;
+        int rval;
+
+		for(int i = 0; i < 3; i++) {
+			/* Write a value and make sure we can read it back;
+			 */
+			CPPUNIT_ASSERT_EQUAL(true, db.write(wval));
+			CPPUNIT_ASSERT_EQUAL(true, db.read(rval));
+			CPPUNIT_ASSERT_EQUAL(wval, rval);
+			/* Then do it again.
+			 */
+		}
+	}
+
+    void Double_buffer_ut::test_read_more_data_than_allocated()
+	{
+        Double_buffer<int> db;
+        Base_double_buffer *bdb = &db;
+        int wval = 9;
+        int rval;
 
         /* Attempt to read and write more data than was allocated by the
          * buffer. This test should fail.
          */
-        Base_double_buffer *bdb = &db;
         CPPUNIT_ASSERT_EQUAL(false, bdb->read(&wval, sizeof(int) + 1));
         CPPUNIT_ASSERT_EQUAL(false, bdb->write(&wval, sizeof(int) + 1));
+	}
 
 #if 0 // Not repeatable with some machines.
+	void Double_buffer_ut::test_exhausted_memory()
+	{
         /* Assume that we cannot allocate a double buffer of type array of the
          * maximum number of ints. (Exhaust memory).
          */
@@ -49,12 +74,18 @@ namespace SRTX {
         CPPUNIT_ASSERT_EQUAL(false, db_big.is_valid());
         CPPUNIT_ASSERT_EQUAL(false, db_big.write(&wval, sizeof(int)));
         CPPUNIT_ASSERT_EQUAL(false, db_big.read(&rval, sizeof(int)));
+	}
 #endif
+
+    void Double_buffer_ut::test_double_buffer_copy()
+    {
+        Double_buffer<int> db;
+        Double_buffer<int> db2;
+        int wval = 4;
+        int rval;
 
         /* Test the double buffer copy operation.
          */
-        Double_buffer<int> db2;
-        wval = 4;
         CPPUNIT_ASSERT_EQUAL(true, db.write(wval));
         CPPUNIT_ASSERT_EQUAL(true, db2.write(0));
         CPPUNIT_ASSERT_EQUAL(true, db.read(rval));
@@ -64,6 +95,12 @@ namespace SRTX {
         CPPUNIT_ASSERT_EQUAL(true, copy_entry(db2, db, sizeof(int)));
         CPPUNIT_ASSERT_EQUAL(true, db2.read(rval));
         CPPUNIT_ASSERT_EQUAL(wval, rval);
+	}
+
+	void Double_buffer_ut::test_double_buffer_copy_too_much()
+	{
+		Double_buffer<int> db;
+		Double_buffer<int> db2;
 
         /* Now let's try some copy operations that should fail.
          */

--- a/SRTX/Double_buffer_ut.h
+++ b/SRTX/Double_buffer_ut.h
@@ -8,14 +8,14 @@ namespace SRTX {
 
         CPPUNIT_TEST_SUITE(Double_buffer_ut);
 
-		CPPUNIT_TEST(test_double_buffer_initialization);
-		CPPUNIT_TEST(test_write_and_read_back_value);
-		CPPUNIT_TEST(test_write_and_read_value_multiple_times);
-		CPPUNIT_TEST(test_read_more_data_than_allocated);
-		CPPUNIT_TEST(test_double_buffer_copy);
-		CPPUNIT_TEST(test_double_buffer_copy_too_much);
+        CPPUNIT_TEST(test_double_buffer_initialization);
+        CPPUNIT_TEST(test_write_and_read_back_value);
+        CPPUNIT_TEST(test_write_and_read_value_multiple_times);
+        CPPUNIT_TEST(test_read_more_data_than_allocated);
+        CPPUNIT_TEST(test_double_buffer_copy);
+        CPPUNIT_TEST(test_double_buffer_copy_too_much);
 #if 0
-		CPPUNIT_TEST_SUITE(test_exhausted_memory);
+        CPPUNIT_TEST_SUITE(test_exhausted_memory);
 #endif
 
         CPPUNIT_TEST_SUITE_END();
@@ -25,12 +25,12 @@ namespace SRTX {
         void tearDown();
 
       protected:
-		void test_double_buffer_initialization();
-		void test_write_and_read_back_value();
-		void test_write_and_read_value_multiple_times();
-		void test_read_more_data_than_allocated();
-		void test_double_buffer_copy();
-		void test_double_buffer_copy_too_much();
+        void test_double_buffer_initialization();
+        void test_write_and_read_back_value();
+        void test_write_and_read_value_multiple_times();
+        void test_read_more_data_than_allocated();
+        void test_double_buffer_copy();
+        void test_double_buffer_copy_too_much();
     };
 
     CPPUNIT_TEST_SUITE_REGISTRATION(Double_buffer_ut);

--- a/SRTX/Double_buffer_ut.h
+++ b/SRTX/Double_buffer_ut.h
@@ -8,7 +8,15 @@ namespace SRTX {
 
         CPPUNIT_TEST_SUITE(Double_buffer_ut);
 
-        CPPUNIT_TEST(test_double_buffer);
+		CPPUNIT_TEST(test_double_buffer_initialization);
+		CPPUNIT_TEST(test_write_and_read_back_value);
+		CPPUNIT_TEST(test_write_and_read_value_multiple_times);
+		CPPUNIT_TEST(test_read_more_data_than_allocated);
+		CPPUNIT_TEST(test_double_buffer_copy);
+		CPPUNIT_TEST(test_double_buffer_copy_too_much);
+#if 0
+		CPPUNIT_TEST_SUITE(test_exhausted_memory);
+#endif
 
         CPPUNIT_TEST_SUITE_END();
 
@@ -17,7 +25,12 @@ namespace SRTX {
         void tearDown();
 
       protected:
-        void test_double_buffer();
+		void test_double_buffer_initialization();
+		void test_write_and_read_back_value();
+		void test_write_and_read_value_multiple_times();
+		void test_read_more_data_than_allocated();
+		void test_double_buffer_copy();
+		void test_double_buffer_copy_too_much();
     };
 
     CPPUNIT_TEST_SUITE_REGISTRATION(Double_buffer_ut);

--- a/SRTX/Mutex_ut.cpp
+++ b/SRTX/Mutex_ut.cpp
@@ -48,20 +48,20 @@ namespace SRTX {
         CPPUNIT_ASSERT_EQUAL(true, m.is_valid());
         CPPUNIT_ASSERT_EQUAL(true, m.lock());
         CPPUNIT_ASSERT_EQUAL(true, m.unlock());
-	}
+    }
 
     void Mutex_ut::test_mutex_second_to_lock()
     {
         Mutex m;
-		pthread_t thread;
+        pthread_t thread;
         Reference_time &rtime = Reference_time::get_instance();
 
         CPPUNIT_ASSERT_EQUAL(true, m.is_valid());
 
         /* Create a thread that will lock our mutex for 1 second
          */
-		int rc = pthread_create(&thread, NULL, Mutex_ut::lock_mutex_sleep_1_sec, (void*) &m);
-		CPPUNIT_ASSERT_EQUAL(0, rc);
+        int rc = pthread_create(&thread, NULL, Mutex_ut::lock_mutex_sleep_1_sec, (void*) &m);
+        CPPUNIT_ASSERT_EQUAL(0, rc);
 
         /* Save the time before our current thread attempts to lock
          */
@@ -78,18 +78,18 @@ namespace SRTX {
         CPPUNIT_ASSERT_EQUAL(true, m.unlock());
 
         /* One second should have passed
-		 * due to the periodic nature of the scheduler's update of Reference_time, give it some leeway (.2s)
-		 */
+         * due to the periodic nature of the scheduler's update of Reference_time, give it some leeway (.2s)
+         */
         CPPUNIT_ASSERT_EQUAL(true, post_lock_time > pre_lock_time + .8 * units::Nanoseconds(units::SEC));
     }
 
     void Mutex_ut::test_mutex_first_to_lock()
     {
         Mutex m;
-		pthread_t thread;
-		pthread_attr_t thread_attr;
+        pthread_t thread;
+        pthread_attr_t thread_attr;
         Reference_time &rtime = Reference_time::get_instance();
-		void *status;
+        void *status;
 
         /* Lock the mutex right here
          */
@@ -97,53 +97,53 @@ namespace SRTX {
 
         /* Create a joinable thread that will lock our mutex for 1 second
          */
-		pthread_attr_init(&thread_attr);
-		pthread_attr_setdetachstate(&thread_attr, PTHREAD_CREATE_JOINABLE);
-		int rc = pthread_create(&thread, &thread_attr, Mutex_ut::lock_mutex_sleep_1_sec, (void*) &m);
+        pthread_attr_init(&thread_attr);
+        pthread_attr_setdetachstate(&thread_attr, PTHREAD_CREATE_JOINABLE);
+        int rc = pthread_create(&thread, &thread_attr, Mutex_ut::lock_mutex_sleep_1_sec, (void*) &m);
 
-		/* no RAII to help us here -- clean up thread_attr before making any assertions
-		 */
-		pthread_attr_destroy(&thread_attr);
-		CPPUNIT_ASSERT_EQUAL(0, rc);
+        /* no RAII to help us here -- clean up thread_attr before making any assertions
+         */
+        pthread_attr_destroy(&thread_attr);
+        CPPUNIT_ASSERT_EQUAL(0, rc);
 
-		/* Save the current time before we release the lock
-		 */
+        /* Save the current time before we release the lock
+         */
         units::Nanoseconds pre_thread_exit_time = rtime.get_time();
 
-		/* Sleep one second before our new thread gets the lock
-		 */
+        /* Sleep one second before our new thread gets the lock
+         */
         sleep(units::Nanoseconds(units::SEC));
         CPPUNIT_ASSERT_EQUAL(true, m.unlock());
 
-		/* Now that the lock is released, the thread should sleep 1 second before it joins.
-		 */
-		rc = pthread_join(thread, &status);
-		CPPUNIT_ASSERT_EQUAL(0, rc);
+        /* Now that the lock is released, the thread should sleep 1 second before it joins.
+         */
+        rc = pthread_join(thread, &status);
+        CPPUNIT_ASSERT_EQUAL(0, rc);
 
         /* Two seconds should have passed
-		 * due to the periodic nature of the scheduler's update of Reference_time, give it some leeway (.2s)
-		 */
+         * due to the periodic nature of the scheduler's update of Reference_time, give it some leeway (.2s)
+         */
         units::Nanoseconds post_thread_exit_time = rtime.get_time();
         CPPUNIT_ASSERT_EQUAL(true, post_thread_exit_time > pre_thread_exit_time + units::Nanoseconds(1.8 * units::SEC));
     }
 
-	void *Mutex_ut::lock_mutex_sleep_1_sec(void *mutex_ptr)
-	{
-		Mutex& m = *(Mutex*) mutex_ptr;
-		CPPUNIT_ASSERT_EQUAL(true, m.is_valid());
+    void *Mutex_ut::lock_mutex_sleep_1_sec(void *mutex_ptr)
+    {
+        Mutex& m = *(Mutex*) mutex_ptr;
+        CPPUNIT_ASSERT_EQUAL(true, m.is_valid());
 
-		/* Lock
-		 */
-		CPPUNIT_ASSERT_EQUAL(true, m.lock());
+        /* Lock
+         */
+        CPPUNIT_ASSERT_EQUAL(true, m.lock());
 
-		/* Sleep
-		 */
+        /* Sleep
+         */
         sleep(units::Nanoseconds(units::SEC));
 
-		/* Unlock & exit
-		 */
+        /* Unlock & exit
+         */
         CPPUNIT_ASSERT_EQUAL(true, m.unlock());
-		pthread_exit(NULL);
-	}
+        pthread_exit(NULL);
+    }
 
 } // namespace

--- a/SRTX/Mutex_ut.cpp
+++ b/SRTX/Mutex_ut.cpp
@@ -1,26 +1,149 @@
+#include <pthread.h>
+#include "base/types.h"
 #include "SRTX/Mutex_ut.h"
-#include "SRTX/Mutex.h"
+#include "Scheduler.h"
+#include "Reference_time.h"
+#include "RTC.h"
 
 namespace SRTX {
 
+    namespace {
+        units::Nanoseconds sched_period(10 * units::MSEC);
+    }
+
     void Mutex_ut::setUp()
     {
+        Scheduler &sched = Scheduler::get_instance();
+        Task_db::value_t task_props;
+
+        task_props.period = sched_period;
+        if(false == sched.set_properties(task_props)) {
+            EPRINTF("Error setting scheduler properties\n");
+            return;
+        }
+
+        /* Set the scheduler to use an external trigger.
+         */
+        //sched.use_external_trigger(true);
+        if(false == sched.start()) {
+            EPRINTF("Error starting the scheduler\n");
+            return;
+        }
+
+        /* Make sure the scheduler has had time to initialize.
+         */
+        sleep(units::Nanoseconds(0.1 * units::SEC));
     }
 
     void Mutex_ut::tearDown()
     {
+        Scheduler &sched = Scheduler::get_instance();
+        sched.stop();
     }
 
-    void Mutex_ut::test_mutex()
+    void Mutex_ut::test_mutex_no_contention()
     {
         Mutex m;
 
-        /* This test is certainly not exhoustive. We'll need to create multiple
-         * threads to give it a real workout.
-         */
         CPPUNIT_ASSERT_EQUAL(true, m.is_valid());
         CPPUNIT_ASSERT_EQUAL(true, m.lock());
         CPPUNIT_ASSERT_EQUAL(true, m.unlock());
+	}
+
+    void Mutex_ut::test_mutex_second_to_lock()
+    {
+        Mutex m;
+		pthread_t thread;
+        Reference_time &rtime = Reference_time::get_instance();
+
+        CPPUNIT_ASSERT_EQUAL(true, m.is_valid());
+
+        /* Create a thread that will lock our mutex for 1 second
+         */
+		int rc = pthread_create(&thread, NULL, Mutex_ut::lock_mutex_sleep_1_sec, (void*) &m);
+		CPPUNIT_ASSERT_EQUAL(0, rc);
+
+        /* Save the time before our current thread attempts to lock
+         */
+        units::Nanoseconds pre_lock_time = rtime.get_time();
+
+        /* Make sure the competing thread locks first
+         */
+        sleep(units::Nanoseconds(0.5* units::SEC));
+
+        /* Now we get the lock ourselves. Save the time
+         */
+        CPPUNIT_ASSERT_EQUAL(true, m.lock());
+        units::Nanoseconds post_lock_time = rtime.get_time();
+        CPPUNIT_ASSERT_EQUAL(true, m.unlock());
+
+        /* One second should have passed
+		 * due to the periodic nature of the scheduler's update of Reference_time, give it some leeway (.2s)
+		 */
+        CPPUNIT_ASSERT_EQUAL(true, post_lock_time > pre_lock_time + .8 * units::Nanoseconds(units::SEC));
     }
+
+    void Mutex_ut::test_mutex_first_to_lock()
+    {
+        Mutex m;
+		pthread_t thread;
+		pthread_attr_t thread_attr;
+        Reference_time &rtime = Reference_time::get_instance();
+		void *status;
+
+        /* Lock the mutex right here
+         */
+        CPPUNIT_ASSERT_EQUAL(true, m.lock());
+
+        /* Create a joinable thread that will lock our mutex for 1 second
+         */
+		pthread_attr_init(&thread_attr);
+		pthread_attr_setdetachstate(&thread_attr, PTHREAD_CREATE_JOINABLE);
+		int rc = pthread_create(&thread, &thread_attr, Mutex_ut::lock_mutex_sleep_1_sec, (void*) &m);
+
+		/* no RAII to help us here -- clean up thread_attr before making any assertions
+		 */
+		pthread_attr_destroy(&thread_attr);
+		CPPUNIT_ASSERT_EQUAL(0, rc);
+
+		/* Save the current time before we release the lock
+		 */
+        units::Nanoseconds pre_thread_exit_time = rtime.get_time();
+
+		/* Sleep one second before our new thread gets the lock
+		 */
+        sleep(units::Nanoseconds(units::SEC));
+        CPPUNIT_ASSERT_EQUAL(true, m.unlock());
+
+		/* Now that the lock is released, the thread should sleep 1 second before it joins.
+		 */
+		rc = pthread_join(thread, &status);
+		CPPUNIT_ASSERT_EQUAL(0, rc);
+
+        /* Two seconds should have passed
+		 * due to the periodic nature of the scheduler's update of Reference_time, give it some leeway (.2s)
+		 */
+        units::Nanoseconds post_thread_exit_time = rtime.get_time();
+        CPPUNIT_ASSERT_EQUAL(true, post_thread_exit_time > pre_thread_exit_time + units::Nanoseconds(1.8 * units::SEC));
+    }
+
+	void *Mutex_ut::lock_mutex_sleep_1_sec(void *mutex_ptr)
+	{
+		Mutex& m = *(Mutex*) mutex_ptr;
+		CPPUNIT_ASSERT_EQUAL(true, m.is_valid());
+
+		/* Lock
+		 */
+		CPPUNIT_ASSERT_EQUAL(true, m.lock());
+
+		/* Sleep
+		 */
+        sleep(units::Nanoseconds(units::SEC));
+
+		/* Unlock & exit
+		 */
+        CPPUNIT_ASSERT_EQUAL(true, m.unlock());
+		pthread_exit(NULL);
+	}
 
 } // namespace

--- a/SRTX/Mutex_ut.h
+++ b/SRTX/Mutex_ut.h
@@ -24,7 +24,7 @@ namespace SRTX {
         void test_mutex_second_to_lock();
         void test_mutex_first_to_lock();
 
-		static void *lock_mutex_sleep_1_sec(void *mutex_ptr);
+        static void *lock_mutex_sleep_1_sec(void *mutex_ptr);
 
     };
 

--- a/SRTX/Mutex_ut.h
+++ b/SRTX/Mutex_ut.h
@@ -2,13 +2,16 @@
 #define __SRTX_MUTEX_UT_H__
 
 #include <cppunit/extensions/HelperMacros.h>
+#include "SRTX/Mutex.h"
 
 namespace SRTX {
     class Mutex_ut : public CppUnit::TestFixture {
 
         CPPUNIT_TEST_SUITE(Mutex_ut);
 
-        CPPUNIT_TEST(test_mutex);
+        CPPUNIT_TEST(test_mutex_no_contention);
+        CPPUNIT_TEST(test_mutex_second_to_lock);
+        CPPUNIT_TEST(test_mutex_first_to_lock);
 
         CPPUNIT_TEST_SUITE_END();
 
@@ -17,7 +20,12 @@ namespace SRTX {
         void tearDown();
 
       protected:
-        void test_mutex();
+        void test_mutex_no_contention();
+        void test_mutex_second_to_lock();
+        void test_mutex_first_to_lock();
+
+		static void *lock_mutex_sleep_1_sec(void *mutex_ptr);
+
     };
 
     CPPUNIT_TEST_SUITE_REGISTRATION(Mutex_ut);


### PR DESCRIPTION
Issue #9 says unit test order is currently dependent, figured I'd take a look. It doesn't say which tests are order dependent, so I just started looking through them all.

So far I noticed that `Double_buffer` had one long test making a variety of assertions, so I split that up. I also noticed that `Mutex` didn't have a test with any contention across threads, so I added one.

_Question_

In terms of the Mutex test, I usually like being pretty low level with my tests, bringing in few dependencies, so my first thought was to use `pthreads`. But I could have used scheduled tasks. Then once I went to use `Reference_time`, I got very strange results. Then I noticed that `Reference_time` requires the scheduler to be running. I could have changed over to use std `sleep` but that seemed going too far.

I had to add some wiggle room to get the tests running, which I'm OK with since we're testing `Mutex` not `Sleep` or `Reference_time`, but also not 100% sure that that wiggle room is Expected Behavior. Also I'm curious, now that I'm starting the `Scheduler` anyway, perhaps if I use `Task` then the wiggle room will go away?

_Anyway_

I'll keep looking through the tests but this seemed a decent enough chunk to start sending your way (especially with all the questions therein).


Any questions/criticisms for me? I'll duly answer/correct.