### PR TITLE
Fix initialization order causing undefined behavior

### DIFF
--- a/SRTX/Base_ring_buffer.cpp
+++ b/SRTX/Base_ring_buffer.cpp
@@ -9,10 +9,15 @@ namespace SRTX {
         : Buffer(nbytes)
         , m_nelems(nelem)
         , m_free(nelem)
+        , m_size(nbytes * nelem)
+		/* be careful here - initialization order is important!
+		 * SPEC: nonstatic data members shall be initialized in the order they were
+		 * declared in the class definition (again regardless of the order of the
+		 * mem-initializers)
+		 */
         , m_buffer(static_cast<char *>(malloc(m_size)))
         , m_head(m_buffer)
         , m_tail(m_buffer)
-        , m_size(nbytes * nelem)
     {
         m_valid = m_sync.is_valid() && (m_buffer != NULL);
     }

--- a/SRTX/Base_ring_buffer.h
+++ b/SRTX/Base_ring_buffer.h
@@ -115,7 +115,14 @@ namespace SRTX {
         unsigned int m_free;
 
         /**
-         * Pointer to the buffer.
+         * Buffer size. This must be declared before m_buffer for proper
+         * initialization order!
+         */
+        const unsigned int m_size;
+
+        /**
+         * Pointer to the buffer. This must be declared after m_size for
+         * proper initialization order!
          */
         char *m_buffer;
 
@@ -128,11 +135,6 @@ namespace SRTX {
          * Buffer tail.
          */
         char *m_tail;
-
-        /**
-         * Buffer size.
-         */
-        const unsigned int m_size;
 
         /**
          * Internal function to read from the buffer.


### PR DESCRIPTION
Currently probably just mallocing more than needed, but running the tests with valgrind turned this bug up. Not sure if this also has security implications...probably not really since heap exploits are much harder than stack exploits.

Either way good to fix.