### PR TITLE
Include sys/time when compiling UDP_connection.cpp on non-Win systems

### DIFF
--- a/net/UDP_connection.cpp
+++ b/net/UDP_connection.cpp
@@ -4,6 +4,10 @@
 
 #include "net/UDP_connection.h"
 
+#if !defined(_WIN32) && !defined(WIN32)
+#include <sys/time.h>
+#endif
+
 namespace net {
 
     static bool set_reuse(int fd)


### PR DESCRIPTION
Without sys/time some compilers will complain that struct timeval is an incomplete type.  This patch gets "make all" working on (for example) Mac OS X; however the sys/time header will typically not be available in Windows build environments so the include needs to be conditional.
